### PR TITLE
[WIP] topPage serverSide 

### DIFF
--- a/app/assets/stylesheets/items-show.scss
+++ b/app/assets/stylesheets/items-show.scss
@@ -127,6 +127,9 @@
       .link{
         text-decoration: none;
       }
+      &__picture {
+        position: relative;
+      }
     }
     .price{
       display: flex;
@@ -299,5 +302,24 @@
   }
   &__icon {
     width: 60%;
+  }
+}
+
+.itemSold {
+  width: 0;
+  height: 0;
+  border-top: 60px solid #ea352d ;
+  border-right: 60px solid transparent;
+  border-bottom: 60px solid transparent;
+  border-left: 60px solid #ea352d ;
+  position: absolute;
+  top: 0;
+  &__inner {
+    transform: rotate(-45deg);
+    font-size: 28px;
+    margin:-25px 0px 0px -55px;
+    color: #fff;
+    letter-spacing: 1px;
+    font-weight: 600;
   }
 }

--- a/app/assets/stylesheets/items.scss
+++ b/app/assets/stylesheets/items.scss
@@ -315,6 +315,7 @@
       &__productList {
         width: 220px;
         float: left;
+        position: relative;
         &__img {
           width: 220px;
           height: 150px;
@@ -472,3 +473,21 @@
   margin: 16px 0 0;
 }
 
+.itemSold {
+  width: 0;
+  height: 0;
+  border-top: 60px solid #ea352d ;
+  border-right: 60px solid transparent;
+  border-bottom: 60px solid transparent;
+  border-left: 60px solid #ea352d ;
+  position: absolute;
+  top: 0;
+  &__inner {
+    transform: rotate(-45deg);
+    font-size: 28px;
+    margin:-25px 0px 0px -55px;
+    color: #fff;
+    letter-spacing: 1px;
+    font-weight: 600;
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,7 +16,6 @@ class ItemsController < ApplicationController
   end
 
   def create
-    Item.create(item_params)
   end 
 
   def destroy
@@ -30,11 +29,6 @@ class ItemsController < ApplicationController
   end
 
   def confirm
-  end
-
-  private
-  def item_params
-    params.require(:item).permit(:name, :introduction, :price)
   end
   
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
     selling = []
 
     # 未購入商品を取り出して配列sellingに入れる
-    allItems.each do |product|
+    allItems.map do |product|
       if product.users_id.present?
         #何もしない
       else  

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,12 @@
 class ItemsController < ApplicationController
 
   def index
-    @items = Item.all 
-    @items_img = ItemImg.url
+    @newestItems = Item.last(3)
+    @item_img = ItemImg.all
+    allItems = Item.all
+    last3deleted = allItems[0..((allItems.length)-4)]
+    random = last3deleted.shuffle
+    @pickupItems = random.take(3)
   end
 
   def new
@@ -12,12 +16,14 @@ class ItemsController < ApplicationController
   end
 
   def create
+    Item.create(item_params)
   end 
 
   def destroy
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def update
@@ -26,5 +32,9 @@ class ItemsController < ApplicationController
   def confirm
   end
 
+  private
+  def item_params
+    params.require(:item).permit(:name, :introduction, :price)
+  end
   
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,27 @@
 class ItemsController < ApplicationController
 
   def index
-    @newestItems = Item.last(3)
-    @item_img = ItemImg.all
+
     allItems = Item.all
-    last3deleted = allItems[0..((allItems.length)-4)]
+    selling = []
+
+    # 未購入商品を取り出して配列sellingに入れる
+    allItems.each do |product|
+      if product.users_id.present?
+        #何もしない
+      else  
+        selling << product
+      end
+    end
+
+    # 新着商品の最新の３つを表示
+    @newestItems = selling.last(3)
+    # item_imgテーブルから上記と適した画像を取得
+    @item_img = ItemImg.all
+
+    # ピックアップ商品を3つ表示（3つの未購入かつ最新商品以外）
+    last3deleted = selling[0..((selling.length)-4)]
+    # リロードすると違う商品が表示されるよう、配列をシャッフル
     random = last3deleted.shuffle
     @pickupItems = random.take(3)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
     selling = []
 
     # 未購入商品を取り出して配列sellingに入れる
-    allItems.map do |product|
+    allItems.select do |product|
       if product.users_id.present?
         #何もしない
       else  

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
 
   def index
+    @items = Item.all 
+    @items_img = ItemImg.url
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,18 +2,9 @@ class ItemsController < ApplicationController
 
   def index
 
-    allItems = Item.all
-    selling = []
-
-    # 未購入商品を取り出して配列sellingに入れる
-    allItems.select do |product|
-      if product.users_id.present?
-        #何もしない
-      else  
-        selling << product
-      end
-    end
-
+    # Itemから未購入商品だけを取り出して配列sellingに入れる
+    selling = Item.all.select { |s| s.users_id == nil }
+    
     # 新着商品の最新の３つを表示
     @newestItems = selling.last(3)
     # item_imgテーブルから上記と適した画像を取得

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,7 @@ class Item < ApplicationRecord
   # belongs_to_active_hash :postage_type
   # belongs_to :brand
   # belongs_to :seller, class_name: "User"
-  # belongs_to :buyer, class_name: "User"
+  belongs_to :buyer, class_name: "User"
 
   # enum item_condition: [:new, :like_new, :good, :fair, :poor, :bad]
   # enum trading_status: [:selling, :sold]

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -1,8 +1,8 @@
 %header.TP-header
   .TP-header__inner
     .TP-header__main
-      = image_tag 'material/logo/logo.png', alt:'TopPageIcon', class: 'TP-header__main__icon'
-      = link_to ''
+      = link_to "/items/" do
+        = image_tag 'material/logo/logo.png', alt:'TopPageIcon', class: 'TP-header__main__icon'
       .TP-header__main__searchBox
         = form_with url: '#', class: 'TP-header__main__searchBox--form', local: true do |f|
           = f.text_field :text, placeholder: 'キーワードから探す', rows: '1', class: 'TP-header__main__searchBox--textfield'
@@ -18,8 +18,8 @@
             ブランド
       %ul.TP-header__navi__right
         %li
-          = link_to '', class: 'TP-header__navi__right--links' do
+          = link_to new_user_session_path, class: 'TP-header__navi__right--links' do
             ログイン
         %li
-          = link_to '', class: 'TP-header__navi__right--links' do
+          = link_to new_user_registration_path, class: 'TP-header__navi__right--links' do
             新規会員登録

--- a/app/views/items/_items-show.html.haml
+++ b/app/views/items/_items-show.html.haml
@@ -5,8 +5,7 @@
     .detail
       .detail__picture
         = image_tag @item.item_imgs.find(@item.id).url, height: "200px", width: "250px", class: "camera-pic"
-        -# -if item.buyer_id.present? 
-        -if @item.prefecture_code == 0
+        -if @item.users_id.present? 
           .itemSold
             .itemSold__inner
               SOLD
@@ -26,8 +25,8 @@
             %td ブランド
             %td シャネル
           %tr
-            %td 商品の状態
-            %td 全体的に状態が悪い
+            %td 商品の状態：
+            %td 少し汚れあり
           %tr
             %td 配送料の負担
             %td 着払い(購入者負担)
@@ -46,7 +45,6 @@
       = link_to "#",class: "buy-btn" do
         購入画面に進む
     .explanation
-      商品状態：汚れあり
       %p 
         = "#{@item.introduction}"
     .evaluation

--- a/app/views/items/_items-show.html.haml
+++ b/app/views/items/_items-show.html.haml
@@ -5,6 +5,11 @@
     .detail
       .detail__picture
         = image_tag @item.item_imgs.find(@item.id).url, height: "200px", width: "250px", class: "camera-pic"
+        -# -if item.buyer_id.present? 
+        -if @item.prefecture_code == 0
+          .itemSold
+            .itemSold__inner
+              SOLD
       .detail__text
         %table
           %tr

--- a/app/views/items/_items-show.html.haml
+++ b/app/views/items/_items-show.html.haml
@@ -1,10 +1,10 @@
 .items-show
   .show
     .title
-      まくらカバー
+      = "#{@item.name}"
     .detail
       .detail__picture
-        = image_tag "material/icon/icon_brand.png",height: "200px",width: "250px",class: "camera-pic"
+        = image_tag @item.item_imgs.find(@item.id).url, height: "200px", width: "250px", class: "camera-pic"
       .detail__text
         %table
           %tr
@@ -34,15 +34,16 @@
             %td ４〜７日で発送
     .price
       .price__pay
-        ¥20,000
+        = "#{@item.price}円"
       .price__fee
         (税込)送料別
     .buy-btn
       = link_to "#",class: "buy-btn" do
         購入画面に進む
     .explanation
-      汚れあり
-      %p クリーニング済み
+      商品状態：汚れあり
+      %p 
+        = "#{@item.introduction}"
     .evaluation
       .evaluation__good-btn
         = link_to "#",class: "evaluation-btn" do

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -101,23 +101,24 @@
           %h3.TP-main__pickupItems__productBox__productHead--title
             新規投稿商品
       .TP-main__pickupItems__productBox__productLists
+        - @items.each do |item|
+          .TP-main__pickupItems__productBox__productList
+            = link_to 'items/#{item.id}' do
+              %figure.TP-main__pickupItems__productBox__productList__img
+                = image_tag @items_img, alt: 'TPPickUpItem1', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
+              .TP-main__pickupItems__productBox__productList__body
+                %h3.TP-main__pickupItems__productBox__productList__name
+                  = "#{item.name}"
+                .TP-main__pickupItems__productBox__productList__details
+                  %ul#pickupItemPriceLikeSpace
+                    %li
+                      = "#{item.price}円"
+                    %li 
+                    ★ 0
+                  %p.TP-main__pickupItems__productBox__productList__details--tax
+                    （税込）
         .TP-main__pickupItems__productBox__productList
-          = link_to '' do
-            %figure.TP-main__pickupItems__productBox__productList__img
-              = image_tag 'material/pickupCategory/pickupItem1.jpeg', alt: 'TPPickUpItem1', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-            .TP-main__pickupItems__productBox__productList__body
-              %h3.TP-main__pickupItems__productBox__productList__name
-                商品 1
-              .TP-main__pickupItems__productBox__productList__details
-                %ul#pickupItemPriceLikeSpace
-                  %li
-                    1000円
-                  %li 
-                  ★ 0
-                %p.TP-main__pickupItems__productBox__productList__details--tax
-                  （税込）
-        .TP-main__pickupItems__productBox__productList
-          = link_to '' do
+          = link_to 'items/index' do
             %figure.TP-main__pickupItems__productBox__productList__img
               = image_tag 'material/pickupCategory/pickupItem2.jpeg', alt: 'TPPickUpItem2', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
             .TP-main__pickupItems__productBox__productList__body
@@ -132,7 +133,7 @@
                 %p.TP-main__pickupItems__productBox__productList__details--tax
                   （税込）
         .TP-main__pickupItems__productBox__productList
-          = link_to '' do
+          = link_to 'items/index' do
             %figure.TP-main__pickupItems__productBox__productList__img
               = image_tag 'material/pickupCategory/pickupItem3.jpeg', alt: 'TPPickUpItem3', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
             .TP-main__pickupItems__productBox__productList__body
@@ -156,7 +157,7 @@
             アーカイバ
       .TP-main__pickupItems__productBox__productLists
         .TP-main__pickupItems__productBox__productList
-          = link_to '' do
+          = link_to 'items/index' do
             %figure.TP-main__pickupItems__productBox__productList__img
               = image_tag 'material/pickupBrand/pickupItem4.jpeg', alt: 'TPPickUpItem1', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
             .TP-main__pickupItems__productBox__productList__body
@@ -171,7 +172,7 @@
                 %p.TP-main__pickupItems__productBox__productList__details--tax
                   （税込）
         .TP-main__pickupItems__productBox__productList
-          = link_to '' do
+          = link_to 'items/index' do
             %figure.TP-main__pickupItems__productBox__productList__img
               = image_tag 'material/pickupBrand/pickupItem5.jpeg', alt: 'TPPickUpItem2', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
             .TP-main__pickupItems__productBox__productList__body
@@ -186,7 +187,7 @@
                 %p.TP-main__pickupItems__productBox__productList__details--tax
                   （税込）
         .TP-main__pickupItems__productBox__productList
-          = link_to '' do
+          = link_to 'items/index' do
             %figure.TP-main__pickupItems__productBox__productList__img
               = image_tag 'material/pickupBrand/pickupItem6.jpeg', alt: 'TPPickUpItem3', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
             .TP-main__pickupItems__productBox__productList__body

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -94,18 +94,18 @@
           お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
   %section.TP-main__pickupItems
     %h2.TP-main__pickupItems__head
-      ピックアップカテゴリー
+      新着アイテム
     .TP-main__pickupItems__productBox
       .TP-main__pickupItems__productBox__productHead
         = link_to '' do
           %h3.TP-main__pickupItems__productBox__productHead--title
             新規投稿商品
       .TP-main__pickupItems__productBox__productLists
-        - @items.each do |item|
+        - @newestItems.each do |item|
           .TP-main__pickupItems__productBox__productList
-            = link_to 'items/#{item.id}' do
+            = link_to "/items/#{item.id}" do
               %figure.TP-main__pickupItems__productBox__productList__img
-                = image_tag @items_img, alt: 'TPPickUpItem1', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
+                = image_tag item.item_imgs.find(item.id).url, alt: 'TPPickUpItem', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
               .TP-main__pickupItems__productBox__productList__body
                 %h3.TP-main__pickupItems__productBox__productList__name
                   = "#{item.name}"
@@ -117,90 +117,61 @@
                     ★ 0
                   %p.TP-main__pickupItems__productBox__productList__details--tax
                     （税込）
-        .TP-main__pickupItems__productBox__productList
-          = link_to 'items/index' do
-            %figure.TP-main__pickupItems__productBox__productList__img
-              = image_tag 'material/pickupCategory/pickupItem2.jpeg', alt: 'TPPickUpItem2', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-            .TP-main__pickupItems__productBox__productList__body
-              %h3.TP-main__pickupItems__productBox__productList__name
-                商品 2
-              .TP-main__pickupItems__productBox__productList__details
-                %ul#pickupItemPriceLikeSpace
-                  %li
-                    2000円
-                  %li 
-                  ★ 0
-                %p.TP-main__pickupItems__productBox__productList__details--tax
-                  （税込）
-        .TP-main__pickupItems__productBox__productList
-          = link_to 'items/index' do
-            %figure.TP-main__pickupItems__productBox__productList__img
-              = image_tag 'material/pickupCategory/pickupItem3.jpeg', alt: 'TPPickUpItem3', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-            .TP-main__pickupItems__productBox__productList__body
-              %h3.TP-main__pickupItems__productBox__productList__name
-                商品 3
-              .TP-main__pickupItems__productBox__productList__details
-                %ul#pickupItemPriceLikeSpace
-                  %li
-                    3000円
-                  %li 
-                  ★ 0
-                %p.TP-main__pickupItems__productBox__productList__details--tax
-                  （税込）
   %section.TP-main__pickupItems
     %h2.TP-main__pickupItems__head
-      ピックアップブランド
+      ピックアップアイテム
     .TP-main__pickupItems__productBox
       .TP-main__pickupItems__productBox__productHead
         = link_to '' do
           %h3.TP-main__pickupItems__productBox__productHead--title
             アーカイバ
       .TP-main__pickupItems__productBox__productLists
-        .TP-main__pickupItems__productBox__productList
-          = link_to 'items/index' do
-            %figure.TP-main__pickupItems__productBox__productList__img
-              = image_tag 'material/pickupBrand/pickupItem4.jpeg', alt: 'TPPickUpItem1', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-            .TP-main__pickupItems__productBox__productList__body
-              %h3.TP-main__pickupItems__productBox__productList__name
-                商品 1
-              .TP-main__pickupItems__productBox__productList__details
-                %ul#pickupItemPriceLikeSpace
-                  %li
-                    1000円
-                  %li 
-                  ★ 0
-                %p.TP-main__pickupItems__productBox__productList__details--tax
-                  （税込）
-        .TP-main__pickupItems__productBox__productList
-          = link_to 'items/index' do
-            %figure.TP-main__pickupItems__productBox__productList__img
-              = image_tag 'material/pickupBrand/pickupItem5.jpeg', alt: 'TPPickUpItem2', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-            .TP-main__pickupItems__productBox__productList__body
-              %h3.TP-main__pickupItems__productBox__productList__name
-                商品 2
-              .TP-main__pickupItems__productBox__productList__details
-                %ul#pickupItemPriceLikeSpace
-                  %li
-                    2000円
-                  %li 
-                  ★ 0
-                %p.TP-main__pickupItems__productBox__productList__details--tax
-                  （税込）
-        .TP-main__pickupItems__productBox__productList
-          = link_to 'items/index' do
-            %figure.TP-main__pickupItems__productBox__productList__img
-              = image_tag 'material/pickupBrand/pickupItem6.jpeg', alt: 'TPPickUpItem3', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-            .TP-main__pickupItems__productBox__productList__body
-              %h3.TP-main__pickupItems__productBox__productList__name
-                商品 3
-              .TP-main__pickupItems__productBox__productList__details
-                %ul#pickupItemPriceLikeSpace
-                  %li
-                    3000円
-                  %li 
-                  ★ 0
-                %p.TP-main__pickupItems__productBox__productList__details--tax
-                  （税込）
+        - @pickupItems.each do |item|
+          .TP-main__pickupItems__productBox__productList
+            = link_to "/items/#{item.id}" do
+              %figure.TP-main__pickupItems__productBox__productList__img
+                = image_tag item.item_imgs.find(item.id).url, alt: 'TPPickUpItem1', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
+              .TP-main__pickupItems__productBox__productList__body
+                %h3.TP-main__pickupItems__productBox__productList__name
+                  = "#{item.name}"
+                .TP-main__pickupItems__productBox__productList__details
+                  %ul#pickupItemPriceLikeSpace
+                    %li
+                      = "#{item.price}円"
+                    %li 
+                    ★ 0
+                  %p.TP-main__pickupItems__productBox__productList__details--tax
+                    （税込）
+        -# .TP-main__pickupItems__productBox__productList
+        -#   = link_to 'items/index' do
+        -#     %figure.TP-main__pickupItems__productBox__productList__img
+        -#       = image_tag 'material/pickupBrand/pickupItem5.jpeg', alt: 'TPPickUpItem2', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
+        -#     .TP-main__pickupItems__productBox__productList__body
+        -#       %h3.TP-main__pickupItems__productBox__productList__name
+        -#         商品 2
+        -#       .TP-main__pickupItems__productBox__productList__details
+        -#         %ul#pickupItemPriceLikeSpace
+        -#           %li
+        -#             2000円
+        -#           %li 
+        -#           ★ 0
+        -#         %p.TP-main__pickupItems__productBox__productList__details--tax
+        -#           （税込）
+        -# .TP-main__pickupItems__productBox__productList
+        -#   = link_to 'items/index' do
+        -#     %figure.TP-main__pickupItems__productBox__productList__img
+        -#       = image_tag 'material/pickupBrand/pickupItem6.jpeg', alt: 'TPPickUpItem3', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
+        -#     .TP-main__pickupItems__productBox__productList__body
+        -#       %h3.TP-main__pickupItems__productBox__productList__name
+        -#         商品 3
+        -#       .TP-main__pickupItems__productBox__productList__details
+        -#         %ul#pickupItemPriceLikeSpace
+        -#           %li
+        -#             3000円
+        -#           %li 
+        -#           ★ 0
+        -#         %p.TP-main__pickupItems__productBox__productList__details--tax
+        -#           （税込）
   %section.TP-main__appBanner 
     .TP-main__appBanner__inner 
       %h2.TP-main__appBanner__inner__title

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -117,8 +117,7 @@
                     ★ 0
                   %p.TP-main__pickupItems__productBox__productList__details--tax
                     （税込）
-            -# -if item.buyer_id.present? 
-            -if item.prefecture_code == 0
+            -if item.users_id.present? 
               .itemSold
                 .itemSold__inner
                   SOLD
@@ -147,8 +146,7 @@
                     ★ 0
                   %p.TP-main__pickupItems__productBox__productList__details--tax
                     （税込）
-              -# -if item.buyer_id.present? 
-              -if item.prefecture_code == 0
+              -if item.users_id.present? 
                 .itemSold
                   .itemSold__inner
                     SOLD

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -117,6 +117,11 @@
                     ★ 0
                   %p.TP-main__pickupItems__productBox__productList__details--tax
                     （税込）
+            -# -if item.buyer_id.present? 
+            -if item.prefecture_code == 0
+              .itemSold
+                .itemSold__inner
+                  SOLD
   %section.TP-main__pickupItems
     %h2.TP-main__pickupItems__head
       ピックアップアイテム
@@ -142,36 +147,11 @@
                     ★ 0
                   %p.TP-main__pickupItems__productBox__productList__details--tax
                     （税込）
-        -# .TP-main__pickupItems__productBox__productList
-        -#   = link_to 'items/index' do
-        -#     %figure.TP-main__pickupItems__productBox__productList__img
-        -#       = image_tag 'material/pickupBrand/pickupItem5.jpeg', alt: 'TPPickUpItem2', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-        -#     .TP-main__pickupItems__productBox__productList__body
-        -#       %h3.TP-main__pickupItems__productBox__productList__name
-        -#         商品 2
-        -#       .TP-main__pickupItems__productBox__productList__details
-        -#         %ul#pickupItemPriceLikeSpace
-        -#           %li
-        -#             2000円
-        -#           %li 
-        -#           ★ 0
-        -#         %p.TP-main__pickupItems__productBox__productList__details--tax
-        -#           （税込）
-        -# .TP-main__pickupItems__productBox__productList
-        -#   = link_to 'items/index' do
-        -#     %figure.TP-main__pickupItems__productBox__productList__img
-        -#       = image_tag 'material/pickupBrand/pickupItem6.jpeg', alt: 'TPPickUpItem3', class: 'TP-main__pickupItems__productBox__productList__img--jpeg'
-        -#     .TP-main__pickupItems__productBox__productList__body
-        -#       %h3.TP-main__pickupItems__productBox__productList__name
-        -#         商品 3
-        -#       .TP-main__pickupItems__productBox__productList__details
-        -#         %ul#pickupItemPriceLikeSpace
-        -#           %li
-        -#             3000円
-        -#           %li 
-        -#           ★ 0
-        -#         %p.TP-main__pickupItems__productBox__productList__details--tax
-        -#           （税込）
+              -# -if item.buyer_id.present? 
+              -if item.prefecture_code == 0
+                .itemSold
+                  .itemSold__inner
+                    SOLD
   %section.TP-main__appBanner 
     .TP-main__appBanner__inner 
       %h2.TP-main__appBanner__inner__title

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,4 +1,5 @@
 .wrapper
   = render "header"
   = render "items-show"
+  -# = render "appBanner"
   = render "footer" 

--- a/db/migrate/20200525054403_create_items.rb
+++ b/db/migrate/20200525054403_create_items.rb
@@ -12,7 +12,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       # t.references :item_img, null: false, foreign_key:true
       # t.references :category, null: false, foreign_key:true
       # t.references :seller, null: false, foreign_key:true
-      # t.references :buyer, foreign_key:true
+      t.references :buyer, foreign_key:true
       # t.timestamps
       t.timestamps
     end


### PR DESCRIPTION
# What
DBから商品一覧をトップページに表示する実装

# Why
ユーザーがトップページをアクセスすると、最新の出品商品とピックアップ商品がランダムで表示され、購買欲を高めるため。

# How
- 画像素材が表示されている。画像がリンク切れなどになっていない
- 商品の一覧に「画像/価格/商品名」の3つの情報も表示できている
- 売り切れた商品は表示されない、または売り切れたことがわかるようになっている

↓動作確認

トップページにSOLD商品は１つもなく、最新アイテムは固定で、ピックアップアイテムはリロードする度に更新。全体的に必ず違う6つの商品が表示されるようになってる
https://gyazo.com/e16749310b985ef916f0153101acc3a1

画像をクリックすると、詳細ページにアクセスできるようになってる
https://gyazo.com/aea96725ab235cc3bfafcec26ff5c48b

仮にノートパソコンを購入したら、最新アイテムからは外され、違う商品が表示される
https://gyazo.com/12286eded0c4e56d810b18c9a34b3303

ノートパソコンの詳細ページに行くと、ちゃんと画像にSOLDが追加されてる
https://gyazo.com/b5885f1a68ad1bb612a0e87c35154fa5