### PR TITLE
購入機能のフラッシュメッセージ実装

### DIFF
--- a/app/assets/stylesheets/error_messages.scss
+++ b/app/assets/stylesheets/error_messages.scss
@@ -5,3 +5,11 @@
   border:2px solid #990000;
   padding:10px; font-weight: 600;
 }
+
+.notice{
+  color:#262626; 
+  background:#FFEBE8;
+  text-align: center;
+  border:2px solid #990000;
+  padding:10px; font-weight: 600;
+}

--- a/app/assets/stylesheets/error_messages.scss
+++ b/app/assets/stylesheets/error_messages.scss
@@ -8,8 +8,8 @@
 
 .notice{
   color:#262626; 
-  background:#FFEBE8;
+  background:#d6e9ca;
   text-align: center;
-  border:2px solid #990000;
+  border:2px solid #32cd32;
   padding:10px; font-weight: 600;
 }

--- a/app/controllers/credit_cards_controller.rb
+++ b/app/controllers/credit_cards_controller.rb
@@ -87,7 +87,7 @@ class CreditCardsController < ApplicationController
       @card.delete
       # 削除が完了しているか判断
       if @card.destroy
-        redirect_to new_credit_card_path
+        redirect_to new_credit_card_path, notice: '削除されました'
       else
         # 削除されなかった場合flashメッセージを表示させて、showのビューに移行
         redirect_to credit_card_path(current_user.id), alert: "削除できませんでした。"

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -143,7 +143,7 @@ class ItemsController < ApplicationController
     # 購入テーブル登録ずみ商品は２重で購入されないようにする
     # (２重で決済されることを防ぐ)
     if @item.buyer_id.present?
-      redirect_to item_path(@item.id), alert: "売り切れています。"
+      redirect_to item_path(@item.id), alert: "売り切れています"
     else
       # 同時に2人が同時に購入し、二重で購入処理がされることを防ぐための記述
       @item.with_lock do
@@ -161,9 +161,9 @@ class ItemsController < ApplicationController
             currency: 'jpy'
           )
           @item.update(buyer_id: current_user.id)
-          redirect_to root_path, alert: "購入が完了しました。"
+          redirect_to root_path, alert: "購入が完了しました"
         else
-          redirect_to item_path(@item.id), alert: "クレジットカードを登録してください"
+          redirect_to item_path(@item.id), alert: "マイページからクレジットカードを登録してください"
         end
       end
     end

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -1,4 +1,5 @@
 = render "/items/header"
+= render "/items/notification"
 .credit__main
   .main__contents
     .main__content__title

--- a/app/views/items/_notification.html.haml
+++ b/app/views/items/_notification.html.haml
@@ -1,0 +1,3 @@
+.notifications
+  - flash.each do |key, value|
+    = content_tag(:div, value, class: key)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,5 +1,6 @@
 .wrapper
   = render "header"
+  = render "notification"
   = render "main"
   = render "appBanner"
   = render "footer"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,6 @@
 .wrapper
   = render "header"
+  = render "notification"
   = render "items-show"
   = render "appBanner"
   = render "footer" 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,4 +10,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    .notifications
+      - flash.each do |key, value|
+        = content_tag(:div, value, class: key)
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,4 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
-    .notifications
-      - flash.each do |key, value|
-        = content_tag(:div, value, class: key)
     = yield


### PR DESCRIPTION
# What
フラッシュメッセージの実装

## 実装内容
・登録したクレジットカードを削除→ 1 、成功すれば、'削除されました'　2、失敗なら、"削除できませんでした。"
https://gyazo.com/fc47305273ac87baef509c39e75d2169
・売り切れ商品を購入する→"売り切れています"
https://gyazo.com/59bc376f2576ab5a75c3921550cf9bcb
・クレジットカードを登録せずに購入→"マイページからクレジットカードを登録してください"
https://gyazo.com/b121a9e3ba68259fa3bcd4404d6aa26e
・購入に成功→"購入が完了しました"
https://gyazo.com/86bc7c4f6cd5ee9e2ee158b14d5c503f

# Why
アクションの結果を可視化することで、ユーザーの使いやすさを向上させるため。