### PR TITLE
[WIP]BreadcrumbNavi

### DIFF
--- a/app/assets/javascripts/item-edit.js
+++ b/app/assets/javascripts/item-edit.js
@@ -21,11 +21,6 @@ $(function(){
 
   //編集ページへアクセスしたその時点で起こすアクション
   if (window.location.href.match(/\/items\/\d+\/edit/)){
-    //登録済み画像のプレビュー表示欄の要素を取得する
-    // var prevContent = $('.label-content').prev();
-    // labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-    // $('.label-content').css('width', labelWidth);
-    //プレビューにidを追加
     //各preview-box(画像のボックス)に0~4のidを与える
     $('.preview-box').each(function(index, box){
       $(box).attr('id', `preview-box__${index}`);
@@ -45,15 +40,6 @@ $(function(){
       $('.label-content').hide();
     } 
   }
-  //=============================================================================
-
-  // // ラベルのwidth操作
-  // function setLabel() {
-  //   //プレビューボックスのwidthを取得し、maxから引くことでラベルのwidthを決定
-  //   var prevContent = $('.label-content').prev();
-  //   labelWidth = (620 - $(prevContent).css('width').replace(/[^0-9]/g, ''));
-  //   $('.label-content').css('width', labelWidth);
-  // }
 
   $(document).on('change', '.preview.box', function() {
 
@@ -77,8 +63,6 @@ $(function(){
 
     //hidden-field（ファイルを選択ボタン）のid名の中の数値だけを取得
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
-    //labelボックスのidとforを更新
-    // $('.label-box').attr({id: `label-box--${id}`,for: `item_imgs_attributes_${id}_url`});
     //選択した画像ファイルのオブジェクトを取得
     var file = this.files[0];
     var reader = new FileReader();
@@ -94,9 +78,7 @@ $(function(){
         // プレビュー群の一番右にプレビューを追加
         var prevContent = $('.label-content').prev();
         $(prevContent).append(html);
-
         $(`#item_item_imgs_attributes_${id}__destroy`).prop('checked',false);
-        
         // もしプレビューした画像が５枚目の場合は、カメラアイコンを隠す
         if (id == 4) {
           $('.label-content').hide();
@@ -104,27 +86,8 @@ $(function(){
       }
       //画像ファイル自体をブラウザーに追加
       $(`#preview-box__${id} img`).attr('src', `${image}`);
-      // var count = $('.preview-box').length;
-      //プレビューが5個あったらラベルを隠す 
-      // if (count == 5) { 
-      //   $('.label-content').hide();
-      // }
-
-
-      //プレビュー削除したフィールドにdestroy用のチェックボックスがあった場合、チェックを外す=============
-      // if ($(`#item_imgs_attributes_${id}__destroy`)){
-      //   $(`#item_imgs_attributes_${id}__destroy`).prop('checked',false);
-      // } 
-
-      //ラベルのwidth操作
-      // setLabel();
-      // //ラベルのidとforの値を変更
-      // if(count = 5){
-      //   $('.label-box').attr({id: `label-box--${count}`,for: `item_imgs_attributes_${count}_url`});
-      // }
     }
-    // var count = $('.preview-box').length;
-
+     // 各編画像ボックスに0~4のidを再び与える
     $('.preview-box').each(function(index, box){
       $(box).attr('id', `preview-box__${index}`);
     })
@@ -139,23 +102,12 @@ $(function(){
 
   });
 
-  // カメラアイコンを隠したり、また表示させたり
-
-  // if ($('.preview-box').length == 5) {
-  //   $('.label-content').hide();
-  // } else {
-  //   $('.label-content').show();
-  // }
-
-
-
   // 編集ボタンをクリックして、画像を差し替える
   $(document).on('click', '.preview-box__lower__btns--edit', function() {
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
     $(`#item_item_imgs_attributes_${id}_url`).click();
     $(`#item_item_imgs_attributes_${id}__destroy`).prop('checked',false);
   });
-
 
   // カメラアイコンををクリックして、画像を追加する
   $(document).on('click', '.label-content', function() {
@@ -166,38 +118,9 @@ $(function(){
     // $(`#ite_item_imgs_attributes_${id}__destroy`).prop('checked',false);
   });
 
-    // if (num == 0) {
-    //   var id = 1;
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // } else if (num == 1) {
-    //   var id = 2;
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // } else if (num == 2) {
-    //   var id = 3;
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // } else {
-    //   var id = 4;
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // }
-
-    // if (num == 1) {
-    //   let id = (num + 1); 
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // } else if (num == 2) {
-    //   let id = (num + 2);
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // } else if (num == 3) {
-    //   let id = (num + 3);
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // } else {
-    //   let id = (num + 4);
-    //   $(`#item_imgs_attributes_${id}_url`).click();
-    // }
-
   // 画像の削除
   $(document).on('click', '.preview-box__lower__btns--delete', function() {
     var id = $(this).attr('id').replace(/[^0-9]/g, '');
-    // var count = $('.preview-box').length;
     // idが1~4の画像ボックスが押されたなら、プレビューを消し、checkboxにもチェックを入れる
     if (id >= 1) {
       $(`#preview-box__${id}`).remove();
@@ -211,42 +134,8 @@ $(function(){
     if (num == 4) {
       $('.label-content').show();
     }
-    // $(`#item_imgs_attributes_${id}__destroy`).prop('checked',true);
-
-    //新規登録時と編集時の場合分け==========================================================
-    //新規投稿時
-    //削除用チェックボックスの有無で判定
-    // if ($(`#item_imgs_attributes_${id}__destroy`).length == 0) {
-    //   //フォームの中身を削除 
-    //   $(`#item_imgs_attributes_${id}_url`).val("");
-    //   // var count = $('.preview-box').length;
-    //   //5個めが消されたらラベルを表示
-    //   // if (count == 4) {
-    //   //   $('.label-content').show();
-    //   // }
-    //   // setLabel(count);
-    //   if(id < 5){
-    //     $('.label-box').attr({id: `label-box--${id}`,for: `item_imgs_attributes_${id}_url`});
-    //   }
-
-    // } else {
-
-    //   //投稿編集時
-    //   $(`#item_imgs_attributes_${id}__destroy`).prop('checked',true);
-    //   //5個めが消されたらラベルを表示
-
-    // }
-  });
-
-  $(document).scroll(function () {
     
   });
-  // var r = 0
-  // var photoNum = $('.preview-box').length;
-  // while (r <= photoNum) {
-  //   $(`#item_item_imgs_attributes_${r}__destroy`).prop('checked',false);
-  //   photoNum++;
-  // }
 
 });
 

--- a/app/assets/stylesheets/confirm-main.scss
+++ b/app/assets/stylesheets/confirm-main.scss
@@ -2,6 +2,16 @@
   width: 100%;
   height: 855px;
   background-color: $gray;
+  &__pan {
+    color: #35c8cb;
+    display: flex;
+    width: 700px;
+    margin: 0 auto 6px;
+    .panLink {
+      color: #35c8cb;
+      text-decoration: underline;
+    }
+  }
   .confirm{
     width: 700px;
     height: 100%;

--- a/app/assets/stylesheets/items-edit.scss
+++ b/app/assets/stylesheets/items-edit.scss
@@ -68,6 +68,16 @@
 
 .itemsEdit {
   display: block;
+  &__pan {
+    color: #35c8cb;
+    display: flex;
+    width: 700px;
+    margin: 0 auto 6px;
+    .panLink {
+      color: #35c8cb;
+      text-decoration: underline;
+    }
+  }
   &__mainContainer {
     background-color: white;
     width: 700px;
@@ -100,7 +110,7 @@
       }
       &__photo {
         width: 620px;
-        padding: 40px;
+        padding: 40px 0 20px 0;
         &--head {
           font-size: 16px;
           font-weight: bold;

--- a/app/assets/stylesheets/items-new.scss
+++ b/app/assets/stylesheets/items-new.scss
@@ -6,6 +6,16 @@
   width: 100%;
   height: 100%;
   background-color: $gray;
+  &__pan {
+    color: #35c8cb;
+    display: flex;
+    width: 700px;
+    margin: 0 auto 6px;
+    .panLink {
+      color: #35c8cb;
+      text-decoration: underline;
+    }
+  }
   .items{
     width: 700px;
     height: 100%;

--- a/app/assets/stylesheets/items-show.scss
+++ b/app/assets/stylesheets/items-show.scss
@@ -17,6 +17,16 @@
   height: 1300px;
   background-color: #EEEEEE;
   padding: 50px;
+  &__pan {
+    color: #35c8cb;
+    display: flex;
+    width: 700px;
+    margin: 0 auto 6px;
+    .panLink {
+      color: #35c8cb;
+      text-decoration: underline;
+    }
+  }
   .show{ 
     width: 700px;
     height: 100%;
@@ -279,4 +289,8 @@
 
 .detailsTable {
   height: 100%;
+}
+
+#spacing {
+  margin-left: 10px;
 }

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -184,6 +184,7 @@
   background-color: white;
   margin-left: 15vw;
   .mypage__nav {
+    margin-top: 20px;
     .mypage__nav__head {
       height: 50px;
       background-color: #f8f8f8;

--- a/app/views/items/_confirm-main.html.haml
+++ b/app/views/items/_confirm-main.html.haml
@@ -3,7 +3,7 @@
     = link_to root_path, class: "panLink" do
       トップページ
     %p#spacing >
-    = link_to "/items/#{@item.id}", class: "panLink" do
+    = link_to item_path, class: "panLink" do
       %p#spacing
         = "商品の詳細"
     %p#spacing >

--- a/app/views/items/_confirm-main.html.haml
+++ b/app/views/items/_confirm-main.html.haml
@@ -1,4 +1,14 @@
 .confirm-main
+  .confirm-main__pan
+    = link_to root_path, class: "panLink" do
+      トップページ
+    %p#spacing >
+    = link_to "/items/#{@item.id}", class: "panLink" do
+      %p#spacing
+        = "商品の詳細"
+    %p#spacing >
+    %p#spacing
+      = "商品の購入(#{@item.name})"
   .confirm
     .confirm__title
       .text

--- a/app/views/items/_items-edit.html.haml
+++ b/app/views/items/_items-edit.html.haml
@@ -3,7 +3,7 @@
     = link_to root_path, class: "panLink" do
       トップページ
     %p#spacing >
-    = link_to "/items/#{@item.id}", class: "panLink" do
+    = link_to item_path, class: "panLink" do
       %p#spacing
         = "商品の詳細"
     %p#spacing >

--- a/app/views/items/_items-edit.html.haml
+++ b/app/views/items/_items-edit.html.haml
@@ -1,4 +1,14 @@
 %main.itemsEdit
+  .itemsEdit__pan
+    = link_to root_path, class: "panLink" do
+      トップページ
+    %p#spacing >
+    = link_to "/items/#{@item.id}", class: "panLink" do
+      %p#spacing
+        = "商品の詳細"
+    %p#spacing >
+    %p#spacing
+      = "商品の編集(#{@item.name})"
   %section.itemsEdit__mainContainer
     .inner
       %h2.inner__head
@@ -67,6 +77,7 @@
               = f.text_field :brand, class: 'container-display__text', type: "text", placeholder: '例：75Beegies'
           .container-display
             = f.label :商品の状態
+            %span.edit-form__photo--must 必須
             %p
               = f.select :item_condition_id, [["選択してください",0],["新品・未使用",1],["未使用に近い",2],["目立った傷や汚れなし",3],["やや傷や汚れあり",4],["傷や汚れあり",5],["全体的に状態が悪い",6]],{},class: 'container-display__text'
         .itemsEdit__container

--- a/app/views/items/_items-new.html.haml
+++ b/app/views/items/_items-new.html.haml
@@ -1,4 +1,10 @@
 .items-new
+  .items-new__pan
+    = link_to root_path, class: "panLink" do
+      トップページ
+    %p#spacing >
+    %p#spacing
+      = "商品を出品"
   .items
     = form_with model:@item, local:true do |f|
       .error-message

--- a/app/views/items/_items-show.html.haml
+++ b/app/views/items/_items-show.html.haml
@@ -1,4 +1,10 @@
 .items-show
+  .items-show__pan
+    = link_to root_path, class: "panLink" do
+      トップページ
+    %p#spacing >
+    %p#spacing
+      = "商品の詳細(#{@item.name})"
   .show
     .title
       = "#{@item.name}"

--- a/app/views/users/_mypage_main.html.haml
+++ b/app/views/users/_mypage_main.html.haml
@@ -1,5 +1,11 @@
 .mypage__main
   .main__contents
+    .itemsEdit__pan
+      = link_to root_path, class: "panLink" do
+        トップページ
+      %p#spacing >
+      %p#spacing
+        = "#{@name}さんのマイページ"
     .main__content__first
       .mypage__user__image
         = link_to "#" do


### PR DESCRIPTION
# What 
パンくずの実装

# Why
ユーザーが今WEBサイト内のどの位置にいるのかを視覚的に分かりやすくするため

# 完了の定義
1) マイページのパンくず機能が実装できている (当ページ以外リンクになっている)
2) 出品ページのパンくず機能が実装できている (当ページ以外リンクになっている)
3) 詳細ページのパンくず機能が実装できている (当ページ以外リンクになっている)
4) 編集ページのパンくず機能が実装できている (当ページ以外リンクになっている)
5) 購入確認ページのパンくず機能が実装できている (当ページ以外リンクになっている)

# 完了の定義動作確認
1) https://gyazo.com/962d1e54a796b0829eddced6d8db6fac
2) https://gyazo.com/0741f18787f8defff4d4fcc6b3e03ff4
3) https://gyazo.com/720a89884bd3aa5c2ee8dc3c63998096
4) https://gyazo.com/dc5fc19aba1ea7c73f1041a22acfbb18
5) https://gyazo.com/214213b31805e9fc3d8570d973dd9d41
